### PR TITLE
Change update strategy to 'recreate' to prevent multi-attached PVCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A Helm chart for Kubernetes
 | shared_dir | string | `"shared"` | name of directory to use for shared data |
 | subpath_dir | string | `nil` | Name of directory to use for a user's home directory.  If null then the user's username will be used. |
 | tolerations | list | `[]` |  |
+| updateStrategy.type | string | `"Recreate"` | 'RollingUpdate' or 'Recreate'. Must use Recreate if mounting PVCs due to multi-attach errors. |
 | useSparkServiceAccount | bool | `true` | Set to true, when using blackbalsam. |
 | userStorage.createPVC | bool | `false` | Create a PVC for user's files.  If false then the PVC needs to be created outside of the appstore chart. |
 | userStorage.nfs.createPV | bool | `false` |  |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         {{- include "appstore.selectorLabels" . | nindent 8 }}
     spec:
+      strategy:
+        type: "{{ .Values.updateStrategy.type }}"
       serviceAccountName: {{ include "appstore.fullname" . }}-sa
       initContainers:
       {{- if .Values.securityContext }}

--- a/values.yaml
+++ b/values.yaml
@@ -19,6 +19,10 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
+updateStrategy:
+  # -- 'RollingUpdate' or 'Recreate'. Must use Recreate if mounting PVCs due to multi-attach errors.
+  type: Recreate
+
 serviceAccount:
   # -- specifies whether a service account should be created
   create: true


### PR DESCRIPTION
When a pod mounts a PVC, normally you have to use the [`Recreate` strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) because the default `RollingUpdate` strategy will result in 2+ copies of the same pod running at the same time, mounting the same volume.

We've been able to get away with that in the past because the NFS storage we use in blackbalsam/mitchell supports [ReadWriteMany](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). Not sure how this has ever worked in GKE though.

I noticed the issue while testing Helx in Sterling, where it threw a "multi-attach" error after upgrading the appstore pod.