### PR TITLE
Move deployment strategy into the Deployment spec where it belongs

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "appstore.labels" . | nindent 4 }}
 spec:
+  strategy:
+    type: "{{ .Values.updateStrategy.type }}"
   selector:
     matchLabels:
       {{- include "appstore.selectorLabels" . | nindent 6 }}
@@ -17,8 +19,6 @@ spec:
       labels:
         {{- include "appstore.selectorLabels" . | nindent 8 }}
     spec:
-      strategy:
-        type: "{{ .Values.updateStrategy.type }}"
       serviceAccountName: {{ include "appstore.fullname" . }}-sa
       initContainers:
       {{- if .Values.securityContext }}


### PR DESCRIPTION
In #6 I had put the "strategy" in the Pod "spec" rather than the Deployment "spec", causing this error: 
```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec): unknown field "strategy" in io.k8s.api.core.v1.PodSpec
```

Now it works :)

```
$ helm install helx .
NAME: helx
LAST DEPLOYED: Thu Nov  4 17:22:51 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
...

$ kubectl describe deploy helx-appstore | grep Strategy
StrategyType:       Recreate
```