### PR TITLE
Reduce scope of k8s permissions granted to appstore

### DIFF
--- a/templates/role.yaml
+++ b/templates/role.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: {{ include "appstore.fullname" . }}-sa
 ---
+# These permissions must only encompass the API calls that Tycho makes.
+# Ref: https://github.com/helxplatform/tycho/blob/master/tycho/kube.py
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -10,21 +12,9 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  attributeRestrictions: null
   resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-    - configmaps
     - pods
-    - secrets
     - services
-    - persistentvolumeclaims
   verbs:
     - create
     - delete
@@ -34,13 +24,18 @@ rules:
     - patch
     - update
     - watch
+- apiGroups:
+  - ""
+  resources:
+    - secrets
+    - persistentvolumeclaims
+  vebs:
+    # Listing secrets can be removed after https://github.com/helxplatform/development/issues/852
+    - list
 - apiGroups:
   - "apps"
   resources:
     - deployments
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
   verbs:
     - create
     - delete
@@ -50,39 +45,6 @@ rules:
     - patch
     - update
     - watch
-- apiGroups:
-  - extensions
-  attributeRestrictions: null
-  resources:
-    - deployments
-    - deployments/scale
-    - ingresses
-    - replicasets
-    - replicasets/scale
-  verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-  - extensions
-  - networking.k8s.io
-  attributeRestrictions: null
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/role.yaml
+++ b/templates/role.yaml
@@ -29,7 +29,7 @@ rules:
   resources:
     - secrets
     - persistentvolumeclaims
-  vebs:
+  verbs:
     # Listing secrets can be removed after https://github.com/helxplatform/development/issues/852
     - list
 - apiGroups:


### PR DESCRIPTION
See https://github.com/helxplatform/development/issues/851 for context.

This PR reduces the permissions down to the following:

* pods, services, deployments:
    - full access (read/write/delete)
* secrets, PVCs:
    - only list/read access. Which can be removed entirely via https://github.com/helxplatform/development/issues/852

This is a subset of the permissions that Tycho *could* potentially need, according to this file: https://github.com/helxplatform/tycho/blob/master/tycho/kube.py

The list of permissions that Tycho *could* use but I think appstore is not using includes:

* creating/deleting NetworkPolicies
* `kubectl port-forward` access (not sure why that's needed, the command errors out silently and causes a 3 second sleep when calling `tycho.start()`)
* deleting pods, replicasets, pvcs. Not sure how those "finalizers" work, but I assume only the service and deployment needs to actually be deleted.