### PR TITLE
Add support for cached SAML metadata

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0-dev
+version: 0.6.0-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.3.dev-c6f479bc
+appVersion: 1.3.1-dev
 
 dependencies:
 - name: postgresql

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -19,8 +19,6 @@ data:
   NRC_PORT: "1247"
   ALLOW_DJANGO_LOGIN: "{{ .Values.django.ALLOW_DJANGO_LOGIN }}"
   ALLOW_SAML_LOGIN: "{{ .Values.django.ALLOW_SAML_LOGIN }}"
-  SAML2_AUTH_ASSERTION_URL: "{{ .Values.django.saml2auth.ASSERTION_URL }}"
-  SAML2_AUTH_ENTITY_ID: "{{ .Values.django.saml2auth.ENTITY_ID }}"
   IMAGE_DOWNLOAD_URL: "{{ .Values.django.IMAGE_DOWNLOAD_URL }}"
   DJANGO_SESSION_IDLE_TIMEOUT: "{{ .Values.django.SESSION_IDLE_TIMEOUT }}"
   TYCHO_INIT_RESOURCES_CPUS: "{{ .Values.init.resources.cpus }}"
@@ -31,4 +29,14 @@ data:
   REACT_APP_WORKSPACES_ENABLED: "{{ .Values.helx_ui.REACT_APP_WORKSPACES_ENABLED }}"
   REACT_APP_HELX_SEARCH_URL: '{{ .Values.helx_ui.REACT_APP_HELX_SEARCH_URL }}'
   REACT_APP_UI_BRAND_NAME: "{{ .Values.helx_ui.REACT_APP_UI_BRAND_NAME }}"
+  {{- if .Values.saml.cache.enabled }}
+  SAML_METADATA_SOURCE: "{{ .Values.saml.cache.APPSTORE_DIRECTORY }}/{{ .Values.saml.cache.APPSTORE_FILE }}"
+  {{- else }}
+  SAML_METADATA_SOURCE: {{ .Values.saml.AUTHORITY_URL }}
+  {{- end }}
+  SAML_FETCH_URL: "{{ .Values.saml.AUTHORITY_URL }}"
+  SAML_FETCH_FILE: "{{ .Values.saml.cache.FETCH_FILE }}"
+  SAML_FETCH_INTERVAL: "{{ .Values.saml.cache.FETCH_INTERVAL }}"
+  SAML_AUTH_ASSERTION_URL: "{{ .Values.saml.ASSERTION_URL }}"
+  SAML_AUTH_ENTITY_ID: "{{ .Values.saml.ENTITY_ID }}"
   GUNICORN_WORKERS: "{{ .Values.gunicorn.workers }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
       containers:
+      
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -105,12 +106,17 @@ spec:
         - name: SAML2_AUTH_ASSERTION_URL
           valueFrom:
             configMapKeyRef:
-              key: SAML2_AUTH_ASSERTION_URL
+              key: SAML_AUTH_ASSERTION_URL
               name: {{ include "appstore.fullname" . }}-env
         - name: SAML2_AUTH_ENTITY_ID
           valueFrom:
             configMapKeyRef:
-              key: SAML2_AUTH_ENTITY_ID
+              key: SAML_AUTH_ENTITY_ID
+              name: {{ include "appstore.fullname" . }}-env
+        - name: SAML_METADATA_SOURCE
+          valueFrom:
+            configMapKeyRef:
+              key: SAML_METADATA_SOURCE
               name: {{ include "appstore.fullname" . }}-env
         - name: OAUTH_DB_DIR
           valueFrom:
@@ -200,7 +206,7 @@ spec:
             secretKeyRef:
               key: OAUTH_PROVIDERS
               name: {{ include "appstore.fullname" . }}
-        {{ if .Values.django.oauth.GITHUB_NAME }}
+        {{ if .Values.oauth.GITHUB_NAME }}
         - name: GITHUB_NAME
           valueFrom:
             secretKeyRef:
@@ -216,22 +222,22 @@ spec:
             secretKeyRef:
               key: GITHUB_SECRET
               name: {{ include "appstore.fullname" . }}
-          {{ if .Values.django.oauth.GITHUB_KEY }}
+        {{ if .Values.oauth.GITHUB_KEY }}
         - name: GITHUB_KEY
           valueFrom:
             secretKeyRef:
               key: GITHUB_KEY
               name: {{ include "appstore.fullname" . }}
-          {{- end }}
-          {{ if .Values.django.oauth.GITHUB_SITES }}
+        {{- end }}
+        {{ if .Values.oauth.GITHUB_SITES }}
         - name: GITHUB_SITES
           valueFrom:
             secretKeyRef:
               key: GITHUB_SITES
               name: {{ include "appstore.fullname" . }}
-          {{- end }}
         {{- end }}
-        {{ if .Values.django.oauth.GOOGLE_NAME }}
+        {{- end }}
+        {{ if .Values.oauth.GOOGLE_NAME }}
         - name: GOOGLE_NAME
           valueFrom:
             secretKeyRef:
@@ -247,20 +253,20 @@ spec:
             secretKeyRef:
               key: GOOGLE_SECRET
               name: {{ include "appstore.fullname" . }}
-          {{ if .Values.django.oauth.GOOGLE_KEY }}
+        {{ if .Values.oauth.GOOGLE_KEY }}
         - name: GOOGLE_KEY
           valueFrom:
             secretKeyRef:
               key: GOOGLE_KEY
               name: {{ include "appstore.fullname" . }}
-          {{- end }}
-          {{ if .Values.django.oauth.GOOGLE_SITES }}
+        {{- end }}
+        {{ if .Values.oauth.GOOGLE_SITES }}
         - name: GOOGLE_SITES
           valueFrom:
             secretKeyRef:
               key: GOOGLE_SITES
               name: {{ include "appstore.fullname" . }}
-          {{- end }}
+        {{- end }}
         {{- end }}
         {{- if .Values.irods.enabled }}
         - name: BRAINI_RODS
@@ -325,6 +331,11 @@ spec:
             secretKeyRef:
               key: PG_DB_USERNAME
               name: {{ include "appstore.fullname" . }}
+        - name: PG_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: PG_DB_PASSWORD
+              name: {{ include "appstore.fullname" . }}
         - name: PG_DB_HOST
           valueFrom:
             secretKeyRef:
@@ -374,6 +385,10 @@ spec:
             mountPath: /usr/src/inst-mgmt/log
             subPath: log
           {{- end}}
+          {{- if .Values.saml.cache.claimName and .Values.saml.cache.enabled }}
+          - name: saml-claim
+            mountPath: {{ .Values.saml.cache.APPSTORE_DIRECTORY }}
+          {{- end }}
       {{- else if .Values.oauth.claimName }}
         volumeMounts:
           {{- if .Values.loadTest }}
@@ -387,6 +402,34 @@ spec:
             mountPath: /usr/src/inst-mgmt/log
             subPath: log
           {{- end}}
+          {{- if and .Values.saml.cache.claimName .Values.saml.cache.enabled }}
+          - name: saml-claim
+            mountPath: {{ .Values.saml.cache.APPSTORE_DIRECTORY }}
+          {{- end }}
+      {{- end }}
+      {{- if .Values.saml.cache.enabled }}
+      - name: {{ .Chart.Name }}-saml-fetch
+        image: wateim/url-fetch:develop
+        imagePullPolicy: Always
+        env:
+        - name: FETCH_URL
+          valueFrom:
+            configMapKeyRef:
+              key: SAML_FETCH_URL
+              name: {{ include "appstore.fullname" . }}-env
+        - name: FETCH_FILE
+          valueFrom:
+            configMapKeyRef:
+              key: SAML_FETCH_FILE
+              name: {{ include "appstore.fullname" . }}-env
+        - name: FETCH_INTERVAL
+          valueFrom:
+            configMapKeyRef:
+              key: SAML_FETCH_INTERVAL
+              name: {{ include "appstore.fullname" . }}-env
+        volumeMounts:
+        - name: saml-claim
+          mountPath: /data
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -408,4 +451,9 @@ spec:
         - name: app-mounts-claim
           persistentVolumeClaim:
             claimName: {{ .Values.appStorage.claimName }}
+      {{- end }}
+      {{- if .Values.saml.cache.claimName }}
+        - name: saml-claim
+          persistentVolumeClaim:
+            claimName: {{ .Values.saml.cache.claimName }}
       {{- end }}

--- a/templates/saml2-cache-pvc.yaml
+++ b/templates/saml2-cache-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.saml.cache.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.saml.cache.claimName }}
+  labels:
+    {{- include "appstore.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.saml.cache.storageSize }}
+  {{ if .Values.saml.cache.storageClass }}
+  storageClassName: {{ .Values.saml.cache.storageClass }}
+  {{- end }}
+{{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -38,24 +38,24 @@ data:
   {{- else }}
   RECIPIENT_EMAILS: ""
   {{- end }}
-  {{ if .Values.django.oauth.OAUTH_PROVIDERS }}
-  OAUTH_PROVIDERS: {{ .Values.django.oauth.OAUTH_PROVIDERS | b64enc }}
+  {{ if .Values.oauth.OAUTH_PROVIDERS }}
+  OAUTH_PROVIDERS: {{ .Values.oauth.OAUTH_PROVIDERS | b64enc }}
   {{- else }}
   OAUTH_PROVIDERS: ""
   {{- end }}
-  {{ if .Values.django.oauth.GITHUB_NAME }}
-  GITHUB_NAME: {{ .Values.django.oauth.GITHUB_NAME | b64enc }}
-  GITHUB_CLIENT_ID: {{ .Values.django.oauth.GITHUB_CLIENT_ID | b64enc }}
-  GITHUB_SECRET: {{ .Values.django.oauth.GITHUB_SECRET | b64enc }}
-  GITHUB_KEY: {{ .Values.django.oauth.GITHUB_KEY | b64enc | quote }}
-  GITHUB_SITES: {{ .Values.django.oauth.GITHUB_SITES | b64enc | quote }}
+  {{ if .Values.oauth.GITHUB_NAME }}
+  GITHUB_NAME: {{ .Values.oauth.GITHUB_NAME | b64enc }}
+  GITHUB_CLIENT_ID: {{ .Values.oauth.GITHUB_CLIENT_ID | b64enc }}
+  GITHUB_SECRET: {{ .Values.oauth.GITHUB_SECRET | b64enc }}
+  GITHUB_KEY: {{ .Values.oauth.GITHUB_KEY | b64enc | quote }}
+  GITHUB_SITES: {{ .Values.oauth.GITHUB_SITES | b64enc | quote }}
   {{- end }}
-  {{ if .Values.django.oauth.GOOGLE_NAME }}
-  GOOGLE_NAME: {{ .Values.django.oauth.GOOGLE_NAME | b64enc }}
-  GOOGLE_CLIENT_ID: {{ .Values.django.oauth.GOOGLE_CLIENT_ID | b64enc }}
-  GOOGLE_SECRET: {{ .Values.django.oauth.GOOGLE_SECRET | b64enc }}
-  GOOGLE_KEY: {{ .Values.django.oauth.GOOGLE_KEY | b64enc | quote }}
-  GOOGLE_SITES: {{ .Values.django.oauth.GOOGLE_SITES | b64enc | quote }}
+  {{ if .Values.oauth.GOOGLE_NAME }}
+  GOOGLE_NAME: {{ .Values.oauth.GOOGLE_NAME | b64enc }}
+  GOOGLE_CLIENT_ID: {{ .Values.oauth.GOOGLE_CLIENT_ID | b64enc }}
+  GOOGLE_SECRET: {{ .Values.oauth.GOOGLE_SECRET | b64enc }}
+  GOOGLE_KEY: {{ .Values.oauth.GOOGLE_KEY | b64enc | quote }}
+  GOOGLE_SITES: {{ .Values.oauth.GOOGLE_SITES | b64enc | quote }}
   {{- end }}
   {{- if .Values.irods.enabled }}
   BRAINI_RODS: {{ .Values.irods.BRAINI_RODS | b64enc }}

--- a/values.yaml
+++ b/values.yaml
@@ -118,22 +118,39 @@ django:
   # -- list of appstore registration emails
   RECIPIENT_EMAILS: ""
   DEV_PHASE: "prod"
-  oauth:
-    # -- oauth providers separated by commas (google, github)
-    OAUTH_PROVIDERS: ""
-    GITHUB_NAME: ""
-    GITHUB_KEY: ""
-    GITHUB_SITES: ""
-    GITHUB_CLIENT_ID: ""
-    GITHUB_SECRET: ""
-    GOOGLE_NAME: ""
-    GOOGLE_KEY: ""
-    GOOGLE_SITES: ""
-    GOOGLE_CLIENT_ID: ""
-    GOOGLE_SECRET: ""
-  saml2auth:
-    ASSERTION_URL: ""
-    ENTITY_ID: ""
+
+oauth:
+  existingClaim: false
+  claimName: appstore-oauth-pvc
+  storageClass:
+  # -- oauth providers separated by commas (google, github)
+  OAUTH_PROVIDERS: ""
+  GITHUB_NAME: ""
+  GITHUB_KEY: ""
+  GITHUB_SITES: ""
+  GITHUB_CLIENT_ID: ""
+  GITHUB_SECRET: ""
+  GOOGLE_NAME: ""
+  GOOGLE_KEY: ""
+  GOOGLE_SITES: ""
+  GOOGLE_CLIENT_ID: ""
+  GOOGLE_SECRET: ""
+
+saml:
+  cache:
+    enabled: false
+    claimName: "saml-cache"
+    storageSize: "20M"
+    storageClass: ""
+    FETCH_URL: ""
+    FETCH_FILE: "/data/saml_metadata.xml"
+    FETCH_INTERVAL: "60000"
+    APPSTORE_DIRECTORY: "/saml"
+    APPSTORE_FILE: "saml_metadata.xml"
+  AUTHORITY_URL: ""
+  ASSERTION_URL: ""
+  ENTITY_ID: ""
+
 irods:
   # -- enable irods support (true | false)
   enabled: false
@@ -163,11 +180,6 @@ userStorage:
     createPV: false
     path:
     server:
-
-oauth:
-  existingClaim: false
-  claimName: appstore-oauth-pvc
-  storageClass:
 
 # Add any extra environment variables not already defined in the chart.
 extraEnv: {}


### PR DESCRIPTION
This PR modifies the appstore helm chart to include a new container that operates in the appstore pod in addition to the main django process.  This 2nd container periodically checks a URL for SAML data and compares it against what it had previously downloaded and if they are different updates the cache.  The results are communicated to appstore using a PVC.

The YAML values tree is moved from `appstore.django.saml2auth` to `appstore.saml` and likewise `appstore.django.oauth` is moved to `appstore.oauth`

SAML cacheing can be enabled or disabled, the default is disabled, here are all of the default values

    saml:
      cache:
        enabled: false
        claimName: "saml-cache"
        storageSize: "20M"
        storageClass: ""
        FETCH_FILE: "/data/saml_metadata.xml"
        FETCH_INTERVAL: "60000"
        APPSTORE_DIRECTORY: "/saml"
        APPSTORE_FILE: "saml_metadata.xml"
      AUTHORITY_URL: ""
      ASSERTION_URL: ""
      ENTITY_ID: ""

Values that must be set include `AUTHORITY_URL`, `ASSERTION_URL`  `ENTITY_ID` as before, also `FETCH_INTERVAL` should be chosen, as the default of once/minute is probably too fast (though it's convenient for testing).

For example appropriate values for testing

    saml:
      AUTHORITY_URL: "https://sso.unc.edu/metadata/unc"
      ASSERTION_URL: "https://eduhelx.renci.org"
      ENTITY_ID: "https://eduhelx.renci.org/saml2_auth/acs/"
      cache:
         enabled: true
