### PR TITLE
Various fixes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.0-dev
+version: 0.6.1-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
   REACT_APP_UI_BRAND_NAME: "{{ .Values.helx_ui.REACT_APP_UI_BRAND_NAME }}"
   {{- if .Values.saml.cache.enabled }}
   SAML_METADATA_SOURCE: "{{ .Values.saml.cache.APPSTORE_DIRECTORY }}/{{ .Values.saml.cache.APPSTORE_FILE }}"
-  {{- else }}
+  {{- else if .Values.saml.AUTHORITY_URL }}
   SAML_METADATA_SOURCE: {{ .Values.saml.AUTHORITY_URL }}
   {{- end }}
   SAML_FETCH_URL: "{{ .Values.saml.AUTHORITY_URL }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -98,6 +98,7 @@ spec:
             configMapKeyRef:
               key: ALLOW_DJANGO_LOGIN
               name: {{ include "appstore.fullname" . }}-env
+        {{- if .Values.saml.AUTHORITY_URL }}
         - name: ALLOW_SAML_LOGIN
           valueFrom:
             configMapKeyRef:
@@ -118,6 +119,7 @@ spec:
             configMapKeyRef:
               key: SAML_METADATA_SOURCE
               name: {{ include "appstore.fullname" . }}-env
+        {{- end }}
         - name: OAUTH_DB_DIR
           valueFrom:
             configMapKeyRef:
@@ -385,7 +387,7 @@ spec:
             mountPath: /usr/src/inst-mgmt/log
             subPath: log
           {{- end}}
-          {{- if .Values.saml.cache.claimName and .Values.saml.cache.enabled }}
+          {{- if and .Values.saml.cache.claimName .Values.saml.cache.enabled }}
           - name: saml-claim
             mountPath: {{ .Values.saml.cache.APPSTORE_DIRECTORY }}
           {{- end }}
@@ -409,8 +411,8 @@ spec:
       {{- end }}
       {{- if .Values.saml.cache.enabled }}
       - name: {{ .Chart.Name }}-saml-fetch
-        image: wateim/url-fetch:develop
-        imagePullPolicy: Always
+        image: "{{ .Values.fetcherImage.repository }}:{{ .Values.fetcherImage.tag }}"
+        imagePullPolicy: {{ .Values.fetcherImage.pullPolicy }}
         env:
         - name: FETCH_URL
           valueFrom:
@@ -452,7 +454,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.appStorage.claimName }}
       {{- end }}
-      {{- if .Values.saml.cache.claimName }}
+      {{- if and .Values.saml.cache.enabled .Values.saml.cache.claimName }}
         - name: saml-claim
           persistentVolumeClaim:
             claimName: {{ .Values.saml.cache.claimName }}

--- a/templates/isolated-apps-network-policy.yaml
+++ b/templates/isolated-apps-network-policy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.security.isolatedApps }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -14,3 +15,4 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: ambassador
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -59,7 +59,7 @@ resources:
     memory: 300Mi
 
 security:
-  isolatedApps: false
+  isolatedApps: true
 
 # -- Choose http or https for the protocol that is used by external users to access
 # the appstore web service.

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,14 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag:
 
+fetcherImage:
+  # -- repository where image is located
+  repository: helxplatform/url-fetch
+  # -- pull policy
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
 # -- credentials for a private repo
 imagePullSecrets: []
 nameOverride: ""
@@ -49,6 +57,9 @@ resources:
   requests:
     cpu: 100m
     memory: 300Mi
+
+security:
+  isolatedApps: false
 
 # -- Choose http or https for the protocol that is used by external users to access
 # the appstore web service.
@@ -142,7 +153,6 @@ saml:
     claimName: "saml-cache"
     storageSize: "20M"
     storageClass: ""
-    FETCH_URL: ""
     FETCH_FILE: "/data/saml_metadata.xml"
     FETCH_INTERVAL: "60000"
     APPSTORE_DIRECTORY: "/saml"


### PR DESCRIPTION
Addresses shortcomings introduced by the previous PR for locally cached SAML data as well as some other lingering problems in the develop branch.

Fixes:

1.  Reference to SAML PVC made optional when setting `saml.cache.enabled` to false.
2.  Also disable use of SAML `METADATA_SOURCE` when `AUTHORITY_URL` is undefined (this is the default).
3.  Make isolating network policy optional by disabling when `security.isolatedApps` is set to false (this is the default).
4. Set ALLOW_SAML_LOGIN only when `AUTHORITY_URL` is defined as in 2.
5. Support defining the url-fetch image similar to appstore image; use `fetcherImage` as compared to `image`

In 5, an example fetcher is

    fetcherImage:
      repository: wateim/url-fetch
      tag: develop
      pullPolicy: Always