### PR TITLE
Changing helx-dev to work like eduhelx-chip690

### DIFF
--- a/values/values-dev.yaml
+++ b/values/values-dev.yaml
@@ -1,6 +1,3 @@
-image:
-  tag: 2023-01-18T16.57Z
-
 ACCOUNT_DEFAULT_HTTP_PROTOCOL: https
 
 django:

--- a/values/values-dev.yaml
+++ b/values/values-dev.yaml
@@ -1,12 +1,17 @@
+image:
+  tag: 2023-01-18T16.57Z
+
 ACCOUNT_DEFAULT_HTTP_PROTOCOL: https
 
 django:
   ALLOW_SAML_LOGIN: true
   DEV_PHASE: dev
   # DOCKSTORE_APPS_BRANCH: "develop"
-  DOCKSTORE_APPS_BRANCH: "projects-volume"
+  # DOCKSTORE_APPS_BRANCH: "projects-volume"
+  DOCKSTORE_APPS_BRANCH: "eduhelx_chip690_fix"
 
-djangoSettings: eduhelx
+# djangoSettings: eduhelx
+djangoSettings: eduhelx-chip690
 
 fetcherImage:
   repository: wateim/url-fetch
@@ -19,7 +24,7 @@ helx_ui:
   REACT_APP_UI_BRAND_NAME: eduhelx
   REACT_APP_WORKSPACES_ENABLED: "true"
 
-logLevel: "debug"
+logLevel: "error"
 
 oauth:
   OAUTH_PROVIDERS: ""
@@ -33,13 +38,13 @@ saml:
      storageSize: "50M"
      FETCH_INTERVAL: 3600000
 
-# userStorage:
-#   createPVC: true
+userStorage:
+  createPVC: true
 
 tycho:
   runAsUser: 30000
   runAsGroup: 1136
   fsGroup: 1136
 
-global:
-  stdnfsPvc: helx-dev-projects-helx-users-pvc
+# global:
+#   stdnfsPvc: helx-dev-projects-helx-users-pvc


### PR DESCRIPTION
Switched to use a dynamic PVC rather than the projects volume.  Changed to use the current helx-apps branch used for eduhelx-chip690.  Set loglevel to 'error' to test logging fix.