### PR TITLE
disable creation of sqlite3 pvc when it is not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ A Helm chart for Kubernetes
 | tycho.subpath_dir | string | `nil` | Name of directory to use for a user's home directory.  If null then the user's username will be used. |
 | updateStrategy.type | string | `"Recreate"` | 'RollingUpdate' or 'Recreate'. Must use Recreate if mounting PVCs due to multi-attach errors. |
 | useSparkServiceAccount | bool | `false` | Set to true, when using blackbalsam. |
-| userStorage.createPVC | bool | `false` | Create a PVC for user's files.  If false then the PVC needs to be created outside of the appstore chart. |
+| userStorage.createPVC | bool | `true` | Create a PVC for user's files.  If false then the PVC needs to be created outside of the appstore chart. |
 | userStorage.nfs.createPV | bool | `false` |  |
 | userStorage.nfs.path | string | `nil` |  |
 | userStorage.nfs.server | string | `nil` |  |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -453,8 +453,10 @@ spec:
           - mountPath: {{ .Values.django.TEST_USERS_PATH }}/test-users/
             name: test-users-volume
           {{- end }}
+          {{- if not .Values.postgresql.enabled }}
           - mountPath: /var/lib/sqlite3
             name: appstore-oauth-volume
+          {{- end }}
           {{- if .Values.appStorage.claimName }}
           - name: app-mounts-claim
             mountPath: /usr/src/inst-mgmt/log
@@ -470,8 +472,10 @@ spec:
           # - mountPath: {{ .Values.django.TEST_USERS_PATH }}/test-users/
           #   name: test-users-volume
           # {{- end }}
+          {{- if not .Values.postgresql.enabled }}
           - mountPath: /var/lib/sqlite3
             name: appstore-oauth-volume
+          {{- end }}
           {{- if .Values.appStorage.claimName }}
           - name: app-mounts-claim
             mountPath: /usr/src/inst-mgmt/log
@@ -511,16 +515,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Always
-      {{- if .Values.oauth.claimName }}
       volumes:
         # {{- if .Values.loadTest }}
         # - name: test-users-volume
         #   secret:
         #     secretName: {{ .Values.django.TEST_USERS_SECRET }}
         # {{- end }}
+      {{- if not .Values.postgresql.enabled }}
+      {{- if .Values.oauth.claimName }}
         - name: appstore-oauth-volume
           persistentVolumeClaim:
             claimName: {{ .Values.oauth.claimName }}
+      {{- end }}
       {{- end }}
       {{- if .Values.appStorage.claimName }}
         - name: app-mounts-claim

--- a/templates/sqlite3-storage.yaml
+++ b/templates/sqlite3-storage.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.postgresql.enabled }}
 {{- if not .Values.oauth.existingClaim }}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -14,4 +15,5 @@ spec:
   {{ if .Values.oauth.storageClass }}
   storageClassName: {{ .Values.oauth.storageClass }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -222,7 +222,7 @@ appStorage:
 userStorage:
   # -- Create a PVC for user's files.  If false then the PVC needs to be created
   # outside of the appstore chart.
-  createPVC: false
+  createPVC: true
   storageSize: 10Gi
   storageClass:
   nfs:


### PR DESCRIPTION
Change values so appstore will deploy on vanilla k8s cluster.