### PR TITLE
switch helx-dev values to use helx-dev branch from helx-apps

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 1.7.4
+version: 1.7.5
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # appstore
 
-![Version: 1.7.4](https://img.shields.io/badge/Version-1.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.7.5](https://img.shields.io/badge/Version-1.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/values/values-dev.yaml
+++ b/values/values-dev.yaml
@@ -8,7 +8,7 @@ django:
   DEV_PHASE: dev
   DOCKSTORE_APPS_BRANCH: 
 
-djangoSettings: eduhelx-sandbox
+djangoSettings: helx
 
 fetcherImage:
   repository: wateim/url-fetch
@@ -18,7 +18,6 @@ fetcherImage:
 helx_ui:
   REACT_APP_HELX_SEARCH_URL: ""
   REACT_APP_SEMANTIC_SEARCH_ENABLED: "false"
-  REACT_APP_UI_BRAND_NAME: eduhelx
   REACT_APP_WORKSPACES_ENABLED: "true"
 
 logLevel: "error"
@@ -50,7 +49,7 @@ tycho:
   initRunAsGroup: 1136
   externalAppRegistryEnabled: true
   externalAppRegistryRepo: "https://github.com/helxplatform/helx-apps/raw"
-  externalAppRegistryBranch: "eduhelx-sandbox"
+  externalAppRegistryBranch: "helx-dev"
 
 global:
   stdnfsPvc: helx-dev-projects-helx-users-pvc


### PR DESCRIPTION
Bumping the version so appstore is redeployed to helx-dev.  The helx-dev branch on helx-apps is the same as the current helx-prod branch.  This will also add the /projects mount in helx app pods (an option in the docker-compose files).