### PR TITLE
Auto whitelist email patterns

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.2.3
+version: 3.2.4
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 appVersion: 3.1.2

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -14,6 +14,8 @@ data:
   OAUTH_DB_DIR: /var/lib/sqlite3
   OAUTH_DB_FILE: DATABASE.sqlite3
   ACCOUNT_DEFAULT_HTTP_PROTOCOL: "{{ .Values.ACCOUNT_DEFAULT_HTTP_PROTOCOL }}"
+  AUTO_WHITELIST_PATTERNS: |
+    {{ toJson .Values.django.AUTO_WHITELIST_PATTERNS | nindent 4 }}
   DEV_PHASE: "{{ .Values.django.DEV_PHASE }}"
   # Just adding these ports temporarily until they have a default value in the code.
   BRAINI_PORT: "1247"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -137,6 +137,11 @@ spec:
             configMapKeyRef:
               key: ACCOUNT_DEFAULT_HTTP_PROTOCOL
               name: {{ include "appstore.fullname" . }}-env
+        - name: AUTO_WHITELIST_PATTERNS
+          valueFrom:
+            configMapKeyRef:
+              key: AUTO_WHITELIST_PATTERNS
+              name: {{ include "appstore.fullname" . }}-env
         - name: DEV_PHASE
           valueFrom:
             configMapKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -147,7 +147,7 @@ django:
   # -- Specify URL to use for the "Image Download" link on the top part of website.
   IMAGE_DOWNLOAD_URL: ""
   # -- idle timeout for user web session
-  SESSION_IDLE_TIMEOUT: 2592000 # 30 days
+  SESSION_IDLE_TIMEOUT: "2592000" # 30 days
   # -- list of appstore registration emails
   RECIPIENT_EMAILS: ""
   # -- should be 'live' unless you are doing some kind of development

--- a/values.yaml
+++ b/values.yaml
@@ -109,6 +109,17 @@ gunicorn:
   workers: 5
 
 django:
+  # Note that these only run on a user's primary alias.
+  # If a user has primary@cs.unc.edu as their primary alias,
+  # and secondary@renci.org as a secondary alias, they will only
+  # be whitelisted automatically if cs.unc.edu emails are allowed.
+  AUTO_WHITELIST_PATTERNS:
+    ### Whitelist all RENCI emails ###
+    - "^[A-Za-z0-9._%+-]+@renci\\.org$"
+    ### Whitelist all UNC emails ###
+    # - "^[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\.)?unc\.edu$"
+    ### Whitelist CS dept. (grad./prof.) UNC emails ###
+    # - "^[A-Za-z0-9._%+-]+@cs\.unc\.edu$"
   # -- create test users for load testing
   CREATE_TEST_USERS: "false"
   # -- parent directory where the users.txt would be mounted
@@ -136,7 +147,7 @@ django:
   # -- Specify URL to use for the "Image Download" link on the top part of website.
   IMAGE_DOWNLOAD_URL: ""
   # -- idle timeout for user web session
-  SESSION_IDLE_TIMEOUT: 3600
+  SESSION_IDLE_TIMEOUT: 2592000 # 30 days
   # -- list of appstore registration emails
   RECIPIENT_EMAILS: ""
   # -- should be 'live' unless you are doing some kind of development

--- a/values.yaml
+++ b/values.yaml
@@ -115,7 +115,7 @@ django:
   # be whitelisted automatically if cs.unc.edu emails are allowed.
   AUTO_WHITELIST_PATTERNS:
     ### Whitelist all RENCI emails ###
-    - "^[A-Za-z0-9._%+-]+@renci\\.org$"
+    # - "^[A-Za-z0-9._%+-]+@renci\\.org$"
     ### Whitelist all UNC emails ###
     # - "^[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\.)?unc\.edu$"
     ### Whitelist CS dept. (grad./prof.) UNC emails ###


### PR DESCRIPTION
Add `AUTO_WHITELIST_PATTERNS` value, which is a list of patterns ran against the user's email to determine if they should automatically be whitelisted. 

By default, allow all RENCI emails through the whitelist.