### PR TITLE
add replicaset permission to apps group

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.1.7
+version: 4.1.8
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 appVersion: 4.1.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 version: 4.1.8
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: 4.1.0
+appVersion: 4.2.1
 dependencies:
   - name: postgresql
     condition: postgresql.enabled

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Kubernetes
 
-![Version: 4.1.8](https://img.shields.io/badge/Version-4.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 4.1.8](https://img.shields.io/badge/Version-4.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.1](https://img.shields.io/badge/AppVersion-4.2.1-informational?style=flat-square)
 
 ## CI/CD
 

--- a/templates/role.yaml
+++ b/templates/role.yaml
@@ -36,6 +36,7 @@ rules:
   - "apps"
   resources:
     - deployments
+    - replicasets
   verbs:
     - create
     - delete


### PR DESCRIPTION
When tearing down a deployment, tycho attempts to wildcard delete all the following resources who have a `tycho-guid=<deployment_sid>` label attached: `deployment, replicaset, pod, persistentvolumeclaim`. Pods and deployments already have deletecollection permission under the appstore service account role. However, neither replica sets nor PVCs have a deletecollection permission.

Even when there are no replicasets/PVCs with the associated tycho-guid label, Tycho does a collection delete against the label for each resource, which requires the permission. Since the role lacks delete permission for both of these, it generates a lot of error logs during app termination even if there weren't any resources to delete anyways.

At the very least, we can mitigate the error logs for replicasets here, no harm done. However, I'd like input regarding whether or not we want to allow deletion of PVCs. I'd heavily lean towards no. If so, we should probably comment out the PVC collection delete in tycho (networkpolicy was also commented out at some point) instead of continuing to attempt the delete  without permission.