### PR TITLE
Add Network Policy to allow traffic from the HeLx infra (resty/nginx, ambassador, appstore-sockets) pods to the appstore pod

### DIFF
--- a/templates/helx-network-policy.yaml
+++ b/templates/helx-network-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-network-policy
+spec:
+  # Allow pods in this Helm release to talk to one another in this namespace.
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Ingress

--- a/templates/helx-network-policy.yaml
+++ b/templates/helx-network-policy.yaml
@@ -3,8 +3,8 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-network-policy
 spec:
-  # Allow resty, ambassador, and nginx pods to communicate with the appstore
-  # pod.
+  # Allow resty, ambassador, nginx, and appstore-socket pods to communicate
+  # with the appstore pod.
   ingress:
   - from:
     - podSelector:

--- a/templates/helx-network-policy.yaml
+++ b/templates/helx-network-policy.yaml
@@ -3,11 +3,18 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-network-policy
 spec:
-  # Allow pods in this Helm release to talk to one another in this namespace.
+  # Allow resty, ambassador, and nginx pods to communicate with the appstore
+  # pod.
   ingress:
   - from:
     - podSelector:
         matchLabels:
-          app.kubernetes.io/instance: {{ .Release.Name }}
+          app.kubernetes.io/name: resty
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: ambassador
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: nginx
   policyTypes:
   - Ingress

--- a/templates/helx-network-policy.yaml
+++ b/templates/helx-network-policy.yaml
@@ -16,5 +16,8 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: nginx
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: appstore-sockets
   policyTypes:
   - Ingress


### PR DESCRIPTION
There is already a network policy to allow traffic from the Ambassador pod(s) to the HeLx app pods.  If the HeLx app pods need to communicate with other pods (gitea? grader-api?) then a network policy will need to be made to allow for that traffic.  To get this to work I removed the line "- podSelector: {}" from the existing ingress.from section of the "default-namespace-isolation" networkpolicy that is added to all our namespaces.  This was tested in my own namespace and I was able to create/delete HeLx app pods and see their status in the web UI.  Traffic between the HeLx app pods was not allowed.  This should also work for when there are multiple HeLx helm chart releases within the same namespace, but would allow for traffic between the infra pods in one release to communicate with the appstore pod in the other release.