### PR TITLE
be more specific in comment in the helx-network-policy template

### DIFF
--- a/templates/helx-network-policy.yaml
+++ b/templates/helx-network-policy.yaml
@@ -3,8 +3,8 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-network-policy
 spec:
-  # Allow resty, ambassador, nginx, and appstore-socket pods to communicate
-  # with the appstore pod.
+  # Allow ingress to pods in the namespace from resty, ambassador, nginx, and
+  # appstore-socket pods.
   ingress:
   - from:
     - podSelector:


### PR DESCRIPTION
I modified the comment in the network policy I added recently.  Realized that it allows ingress traffic to all the pods in the namespace from the resty, ambassador, nginx, and appstore-sockets pods.  This still works to block traffic between the app pods, but is more permissive than I thought.  The network policy can be refined further by someone who knows what HeLx infra pods need to communicate with other HeLx infra pods and on what port.