### PR TITLE
Upgrade postgresql

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.1.9
+version: 4.1.10
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 appVersion: 4.2.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,5 +19,5 @@ appVersion: 4.2.0
 dependencies:
   - name: postgresql
     condition: postgresql.enabled
-    version: "11.6.26"
+    version: "16.7.12"
     repository: "https://charts.bitnami.com/bitnami"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Kubernetes
 
-![Version: 4.1.9](https://img.shields.io/badge/Version-4.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
+![Version: 4.1.10](https://img.shields.io/badge/Version-4.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Additionally there is a workflow that allows bumping the chart version, if this 
 | image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion. Set to "" before release! |
 | imagePostgresql.pullPolicy | string | `"IfNotPresent"` | pull policy |
 | imagePostgresql.repository | string | `"docker.io/bitnami/postgresql"` | repository where postgresql image is located |
-| imagePostgresql.tag | int | `11` | Image tag for postgresql, coordinate this with postgresql dependency. |
+| imagePostgresql.tag | string | `"17.5.0"` | Image tag for postgresql, coordinate this with postgresql dependency. |
 | imagePullSecrets | list | `[]` | credentials for a private repo |
 | imagej.enabled | bool | `true` | Disabling will turn off the creation of secrets/configmaps for ImageJ |
 | irods.BRAINI_RODS | string | `""` |  |

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ imagePostgresql:
   # -- pull policy
   pullPolicy: IfNotPresent
   # -- Image tag for postgresql, coordinate this with postgresql dependency.
-  tag: 11
+  tag: 17.5.0
 
 fetcherImage:
   # -- repository where image is located


### PR DESCRIPTION
Bitnami axed some of the dependencies from dockerhub that the current postgres version we're using required, so we needed to upgrade to a more modern version.