### PR TITLE
Updated app isolation policy to default block all egress from app pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Additionally there is a workflow that allows bumping the chart version, if this 
 | saml.cache.enabled | bool | `false` |  |
 | saml.cache.storageClass | string | `""` |  |
 | saml.cache.storageSize | string | `"20M"` |  |
+| security.appEgressAllowedPods | list | `[]` |  |
+| security.dnsPodSelector | object | `{}` |  |
 | security.isolatedApps | bool | `true` |  |
 | service.name | string | `"http"` |  |
 | service.port | int | `80` |  |

--- a/templates/isolated-apps-network-policy.yaml
+++ b/templates/isolated-apps-network-policy.yaml
@@ -10,27 +10,39 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+  # More permissive policy elsewhere in the namespace may override
+  # this ambassador-only restriction.
   ingress:
   - from:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: ambassador
   egress:
-  # Allow DNS
+  {{- if .Values.security.dnsPodSelector }}
+  # Allow DNS to pods matching the configured selector.
   - to:
     - namespaceSelector: {}
       podSelector:
         matchLabels:
-          k8s-app: kube-dns
-    ports:
+          {{- toYaml .Values.security.dnsPodSelector | nindent 10 }}
+  {{- else }}
+  # Allow DNS on common ports to any destination. Used when no DNS pod
+  # selector is configured — works on most clusters without tuning.
+  - ports:
     - protocol: UDP
       port: 53
     - protocol: TCP
       port: 53
-  # Allow all traffic except to Ambassador pods.
-  # The first peer matches everything outside the cluster pod CIDR
-  # (kubelet probes, external internet, node-local services).
-  # The second peer matches in-cluster pods that are NOT Ambassador.
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+    - protocol: UDP
+      port: 1053
+    - protocol: TCP
+      port: 1053
+  {{- end }}
+  # Allow external (non-cluster) egress.
   - to:
     - ipBlock:
         cidr: 0.0.0.0/0
@@ -38,10 +50,13 @@ spec:
         - 10.0.0.0/8
         - 172.16.0.0/12
         - 192.168.0.0/16
-    - namespaceSelector: {}
-      podSelector:
-        matchExpressions:
-        - key: app.kubernetes.io/name
-          operator: NotIn
-          values: [ambassador]
+  {{- with .Values.security.appEgressAllowedPods }}
+  # Explicitly allowlisted in-cluster destinations.
+  - to:
+    {{- range . }}
+    - podSelector:
+        matchLabels:
+          {{- toYaml . | nindent 10 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -76,6 +76,23 @@ resources:
 
 security:
   isolatedApps: true
+  # In-namespace pods that app pods are allowed to egress to. Each entry is a
+  # map of pod labels (AND-matched within an entry, OR-matched across entries).
+  # Empty by default, so apps are fully isolated from other in-namespace pods.
+  # External egress and DNS remain allowed regardless.
+  # Example: allow apps to reach a postgres database:
+  #   appEgressAllowedPods:
+  #     - app.kubernetes.io/name: my-postgres
+  appEgressAllowedPods: []
+  # Labels identifying the cluster DNS pods, used to permit DNS egress from
+  # app pods. When set, egress is allowed to any pod carrying these labels
+  # on any port. When empty, falls back to permitting egress on common DNS
+  # ports (53, 5353, 1053) to any destination — works out of the box on most
+  # clusters but is broader than a label-based rule.
+  # Examples:
+  #   Stock Kubernetes / CoreDNS:  {k8s-app: kube-dns}
+  #   OpenShift:                   {dns.operator.openshift.io/daemonset-dns: default}
+  dnsPodSelector: {}
 
 # -- Choose http or https for the protocol that is used by external users to access
 # the appstore web service.


### PR DESCRIPTION
Since namespaces like sterling and ASHE have default network policies that permit all ingress traffic between namespace pods, the rule that permits ingress only from ambassador in the app isolation policy isn't effective. This updates the egress portion to restrict all traffic from apps to namespace pods except those explicitly specified in the chart values (e.g. postgres).

Also added a DNS configuration value since this will otherwise block connectivity to the cluster's CoreDNS. If left unspecified, the policy will permit all egress traffic to ports 53, 1053, and 5353 (in the case that the cluster DNS labels aren't known).

For CDSR, these values are in use:
```
security:
  isolatedApps: true
  appEgressAllowedPods:
    - app.kubernetes.io/name: cardiology-postgres
  dnsPodSelector:
    dns.operator.openshift.io/daemonset-dns: default
```