### PR TITLE
Merge ambassador removal changes to chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,10 +12,12 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.1.2
+version: 5.1.3
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
-appVersion: 4.4.2
+# 4.4.1 is the released appstore image carrying the Ambassador-removal changes
+# (private_route resolver, APP_ROUTING_MODE, SECURE_PROXY_SSL_HEADER).
+appVersion: 4.4.1
 dependencies:
   - name: postgresql
     condition: postgresql.enabled

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Kubernetes
 
-![Version: 5.1.2](https://img.shields.io/badge/Version-5.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.2](https://img.shields.io/badge/AppVersion-4.4.2-informational?style=flat-square)
+![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.1](https://img.shields.io/badge/AppVersion-4.4.1-informational?style=flat-square)
 
 ## CI/CD
 
@@ -154,6 +154,7 @@ Additionally there is a workflow that allows bumping the chart version, if this 
 | sqliteStorage.claimName | string | `nil` | If a claim name is not specified, it defaults to appstore-oauth-pvc. |
 | tolerations | list | `[]` |  |
 | tycho.GPUResourceName | string | `"nvidia.com/gpu"` | The GPU resource name that a container can utilize.  Typically this is "nvidia.com/gpu", but other types exist, such as "nvidia.com/mig-1g.5gb" and other manufacturers have their own types. |
+| tycho.appRoutingMode | string | `"proxy"` | How Tycho-launched apps are routed. "proxy" (default on this branch): ClusterIP + /private prefix, backend resolved by an external reverse proxy (resty) via appstore's /api/v1/private-route/ resolver — the de-Ambassador design. "ambassador" (legacy): emit the Ambassador Mapping annotation when Ambassador is present. "none": no routing wiring. |
 | tycho.createHomeDirs | bool | `true` | Create Home and shared directories for users. |
 | tycho.enableInitContainer | bool | `true` | Start the init container to take care of any needed tasks before the main container is started.  This can be to create certain directories or set file permissions. |
 | tycho.enableTrashCli | bool | `false` | Enable trash-cli functionality in tycho-launched apps |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -519,6 +519,8 @@ spec:
         - name: AMBASSADOR_SVC_NAME
           value: {{ .Values.global.ambassador_service_name }}
         {{- end }}
+        - name: APP_ROUTING_MODE
+          value: "{{ .Values.tycho.appRoutingMode }}"
         ports:
         - containerPort: 8000
         volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -299,6 +299,12 @@ extraEnv: {}
 useSparkServiceAccount: false
 
 tycho:
+  # -- How Tycho-launched apps are routed. "ambassador" (default, legacy):
+  # emit the Ambassador Mapping annotation when Ambassador is present.
+  # "proxy": ClusterIP + /private prefix, backend resolved by an external
+  # reverse proxy (resty) via appstore's /api/v1/private-route/ resolver — set
+  # this (and disable Ambassador) to remove Ambassador. "none": no routing wiring.
+  appRoutingMode: ambassador
   # -- Application processes launched will run as this user.
   runAsUser: 0
   # -- Application processes launched will have this group permissions.

--- a/values.yaml
+++ b/values.yaml
@@ -299,12 +299,12 @@ extraEnv: {}
 useSparkServiceAccount: false
 
 tycho:
-  # -- How Tycho-launched apps are routed. "ambassador" (default, legacy):
-  # emit the Ambassador Mapping annotation when Ambassador is present.
-  # "proxy": ClusterIP + /private prefix, backend resolved by an external
-  # reverse proxy (resty) via appstore's /api/v1/private-route/ resolver — set
-  # this (and disable Ambassador) to remove Ambassador. "none": no routing wiring.
-  appRoutingMode: ambassador
+  # -- How Tycho-launched apps are routed. "proxy" (default on this branch):
+  # ClusterIP + /private prefix, backend resolved by an external reverse proxy
+  # (resty) via appstore's /api/v1/private-route/ resolver — the de-Ambassador
+  # design. "ambassador" (legacy): emit the Ambassador Mapping annotation when
+  # Ambassador is present. "none": no routing wiring.
+  appRoutingMode: proxy
   # -- Application processes launched will run as this user.
   runAsUser: 0
   # -- Application processes launched will have this group permissions.


### PR DESCRIPTION
4.4.2 was incorrect originally, not sure why that was there as appstore hasn't yet had that version. 