### PR TITLE
Update NetworkPolicies for de-Ambassador routing

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.1.3
+version: 5.1.4
 # This is the version number of the application being deployed. This version
 # number should be incremented each time you make changes to the application.
 # 4.4.1 is the released appstore image carrying the Ambassador-removal changes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Kubernetes
 
-![Version: 5.1.3](https://img.shields.io/badge/Version-5.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.1](https://img.shields.io/badge/AppVersion-4.4.1-informational?style=flat-square)
+![Version: 5.1.4](https://img.shields.io/badge/Version-5.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.1](https://img.shields.io/badge/AppVersion-4.4.1-informational?style=flat-square)
 
 ## CI/CD
 

--- a/templates/helx-network-policy.yaml
+++ b/templates/helx-network-policy.yaml
@@ -3,19 +3,14 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-network-policy
 spec:
-  # Allow resty, ambassador, nginx, and appstore-socket pods to communicate
-  # with the appstore pod.
+  # Allow resty and appstore-socket pods to communicate with the appstore pod.
+  # (Ambassador and nginx are retired in the de-Ambassador design; resty is the
+  # edge/data plane.)
   ingress:
   - from:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: resty
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: ambassador
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: nginx
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: appstore-sockets

--- a/templates/isolated-apps-network-policy.yaml
+++ b/templates/isolated-apps-network-policy.yaml
@@ -10,13 +10,14 @@ spec:
   policyTypes:
   - Ingress
   - Egress
-  # More permissive policy elsewhere in the namespace may override
-  # this ambassador-only restriction.
+  # Allow ingress to launched apps only from resty (the reverse proxy that
+  # serves /private in the de-Ambassador design). A more permissive policy
+  # elsewhere in the namespace may override this restriction.
   ingress:
   - from:
     - podSelector:
         matchLabels:
-          app.kubernetes.io/name: ambassador
+          app.kubernetes.io/name: resty
   egress:
   {{- if .Values.security.dnsPodSelector }}
   # Allow DNS to pods matching the configured selector.


### PR DESCRIPTION
- helx-network-policy: drop the retired ambassador/nginx podSelectors from the appstore ingress allow-list; keep resty + appstore-sockets.
- isolated-apps-network-policy: allow ingress to launched apps (executor=tycho) from resty instead of ambassador. resty is the reverse proxy that serves /private now, so with isolatedApps enforcement the old ambassador-only rule would have blocked resty->app traffic.

Chart version 5.1.3 -> 5.1.4.